### PR TITLE
add tests and fixtures for SVG and MathML

### DIFF
--- a/tests/fixtures/angular-mathml-closed.html
+++ b/tests/fixtures/angular-mathml-closed.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html ng-app="myApp">
+
+<head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>fixture</title>
+</head>
+
+<body>
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <infinity></infinity>
+    </math>
+</body>
+
+</html>

--- a/tests/fixtures/angular-mathml-self.html
+++ b/tests/fixtures/angular-mathml-self.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html ng-app="myApp">
+
+<head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>fixture</title>
+</head>
+
+<body>
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <infinity/>
+    </math>
+</body>
+
+</html>

--- a/tests/fixtures/angular-svg-closed.html
+++ b/tests/fixtures/angular-svg-closed.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html ng-app="myApp">
+
+<head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>fixture</title>
+</head>
+
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="M10 10 H 90 V 90 H 10 Z" fill="transparent" stroke="black"></path>
+    </svg>
+</body>
+
+</html>

--- a/tests/fixtures/angular-svg-self.html
+++ b/tests/fixtures/angular-svg-self.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html ng-app="myApp">
+
+<head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>fixture</title>
+</head>
+
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <path d="M10 10 H 90 V 90 H 10 Z" fill="transparent" stroke="black"/>
+    </svg>
+</body>
+
+</html>

--- a/tests/test.js
+++ b/tests/test.js
@@ -166,4 +166,30 @@ describe('angular-html5', function () {
         htmlBeautify(contents).should.eql(htmlBeautify(testFile));
     });
 
+    it('should preserve explicitly closed SVG elements', function () {
+        var types = ['closed', 'self'];
+        for (var i = 0; i < types.length; i++) {
+            var filename = './tests/fixtures/angular-svg-' + types[i] + '.html';
+            var htmlify = angularHtml5();
+            var testFile = fs.readFileSync(filename, 'utf8');
+            htmlify.test(testFile).should.eql(true);
+            var contents = htmlify.replace(testFile);
+            //test that SVG elements are explicitly closed
+            contents.should.match(/<path[\s\S]*?([^>]*?\/>|>[\s\S]*?<\/path>)/);
+        }
+    });
+
+    it('should preserve explicitly closed MathML elements', function () {
+        var types = ['closed', 'self'];
+        for (var i = 0; i < types.length; i++) {
+            var filename = './tests/fixtures/angular-mathml-' + types[i] + '.html';
+            var htmlify = angularHtml5();
+            var testFile = fs.readFileSync(filename, 'utf8');
+            htmlify.test(testFile).should.eql(true);
+            var contents = htmlify.replace(testFile);
+            //test that SVG elements are explicitly closed
+            contents.should.match(/<infinity[\s\S]*?([^>]*?\/>|>[\s\S]*?<\/infinity>)/);
+        }
+    });
+
 });


### PR DESCRIPTION
Some tests and fixtures for SVG and MathML parsing/transformation as per #4.

Interestingly, the MathML tests pass, so I wonder if there is already a mechanism in htmlparser2 to conform to the W3C spec - maybe a whitelist of MathML elements or preservation of explicit closing tags/markers on descendants of the `<math>` element? If so, maybe the same could be applied to SVG without too much trouble.

Thanks for taking a look!