### PR TITLE
Remove tagName testing and prefixing completely

### DIFF
--- a/lib/angular-html5.js
+++ b/lib/angular-html5.js
@@ -19,13 +19,6 @@ module.exports = function (params) {
             });
             var foundPrefix = false;
             $('*').each(function (i, el) {
-                // check tagName
-                rPrefix.lastIndex = 0;
-                foundPrefix = rPrefix.test(el.tagName);
-                // early exit
-                if (foundPrefix) {
-                    return false;
-                }
 
                 // check attributes
                 var attrs = Object.keys($(el).attr()).filter(function (attr) {
@@ -60,22 +53,6 @@ module.exports = function (params) {
                     $el.removeAttr(attr);
                 });
             });
-
-            // check tagNames
-            var hasAlteredHtml;
-            do {
-                hasAlteredHtml = false;
-                $('*').each(function (i, el) {
-                    var $el = $(el);
-                    rPrefix.lastIndex = 0;
-                    if (rPrefix.test(el.tagName)) {
-                        hasAlteredHtml = true;
-                        $el.replaceWith(function () {
-                            return $('<data-' + el.tagName + '/>').attr($el.attr()).append($el.html());
-                        });
-                    }
-                });
-            } while (hasAlteredHtml);
 
             return $.html();
         }

--- a/readme.md
+++ b/readme.md
@@ -35,20 +35,6 @@ valid HTML5 tags that start with `data-something`.
 ```
 #### <img src="http://www.w3.org/html/logo/downloads/HTML5_Logo_256.png" alt="HTML5 Valid" width="64" height="64"/>
 
-**angular-html5** looks for `ng-` directives by default and can handle the following cases:
-```html
-<!-- attribute -->
-<ANY ng-directive>
-<!-- regular element -->
-<ng-directive></ng-directive>
-<!-- self closing element -->
-<ng-directive />
-<!-- custom directive prefix -->
-<ui-router></ui-router>
-<!-- your name prefix -->
-<gilad-cool-loader></gilad-cool-loader>
-```
-
 You can add additional prefixes using the option `customPrefixes`.
 
 This plugin plays nice with `type="text/ng-template"` and won't break it.


### PR DESCRIPTION
Custom element names require only to include at least one hyphen ([a bit more strict of course](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name)) to produce valid HTML5 code. Thus it's unexpected and undesirable to prefix them with `data-` (which is meant to be used with attribute names only).